### PR TITLE
Bugfixes

### DIFF
--- a/fc_idealodk/classes/class.idealodk_order_import.php
+++ b/fc_idealodk/classes/class.idealodk_order_import.php
@@ -422,11 +422,23 @@ class idealodk_order_import
         $sId = $db->GetOne($sQ);
         if ($sId && $sId != ""){
             $oProduct = new product($sId);
-            idealodk_logger::log('IDEALO ORDER IMPORT: NOTICE: Product SKU ' . $sSku . '/ ID '. $sId .' loaded');
+            idealodk_logger::log('IDEALO ORDER IMPORT: NOTICE: Product SKU ' . $sSku . '/ ID '. ($oProduct->data['products_id'] ? $oProduct->data['products_id'].' (XTC pID) loaded' : ' no XTC pID product disabled!'));
+            if(empty($oProduct->data['products_id'])){
+                $oProduct->_setStatus($sId,1);
+                $nProduct = new product($sId);
+                $nProduct->_setStatus($sId,0);
+            }else{
+                $nProduct = false;
+            }
+            idealodk_logger::log('IDEALO ORDER IMPORT: NOTICE: Product tmp activated ID '. $nProduct->data['products_id']);
         } else {
             idealodk_logger::log('IDEALO ORDER IMPORT: ERROR: Product SKU ' . $sSku . ' not found');
         }
-        return $oProduct;
+        if ($nProduct){
+            return $nProduct;
+        }else{
+            return $oProduct;
+        }
     }
 
     /**

--- a/fc_idealodk/classes/class.idealodk_order_import.php
+++ b/fc_idealodk/classes/class.idealodk_order_import.php
@@ -427,10 +427,11 @@ class idealodk_order_import
                 $oProduct->_setStatus($sId,1);
                 $nProduct = new product($sId);
                 $nProduct->_setStatus($sId,0);
+                idealodk_logger::log('IDEALO ORDER IMPORT: NOTICE: Product tmp activated ID '. $nProduct->data['products_id'] .'(SKU: '. $sSku . ')');
             }else{
                 $nProduct = false;
             }
-            idealodk_logger::log('IDEALO ORDER IMPORT: NOTICE: Product tmp activated ID '. $nProduct->data['products_id']);
+            
         } else {
             idealodk_logger::log('IDEALO ORDER IMPORT: ERROR: Product SKU ' . $sSku . ' not found');
         }


### PR DESCRIPTION
- deactivated products are now temporarily activated to be stored in the order (which was blank before)
- made support of xt_ship_and_track depending on the plugin being installed/active (caused SQL error before)